### PR TITLE
Update js/bootstrap-phone.format.js

### DIFF
--- a/js/bootstrap-phone.format.js
+++ b/js/bootstrap-phone.format.js
@@ -92,7 +92,7 @@
    'FJ': 'xxxxxxxxx',
    'FI': 'xxxxxxxxx',
    'MK': 'xxxxxxxxx',
-   'FR': '(x)x xx xx xx xx',
+   'FR': 'xx xx xx xx xx',
    'GF': 'xxxxxxxxx',
    'PF': 'xxxxxxxxx',
    'TF': 'xxxxxxxxx',


### PR DESCRIPTION
In France, we don't put parenthesis around the first number. But it is right that we split them in groups of 2.

For example:
06 11 04 18 85
