### PR TITLE
Add support for constraining the country list to a specified set

### DIFF
--- a/docs/assets/js/bootstrap-formhelpers-countries.js
+++ b/docs/assets/js/bootstrap-formhelpers-countries.js
@@ -29,6 +29,18 @@
     this.options = $.extend({}, $.fn.countries.defaults, options)
     this.$element = $(element)
     
+	if (this.options.countrylist) {
+		this.countryList = []
+		this.options.countrylist = this.options.countrylist.split(',')
+        for (var country in CountriesList) {
+			if ($.inArray(country, this.options.countrylist) >= 0) {
+				this.countryList[country] = CountriesList[country]
+			}
+		}
+	} else {
+		this.countryList = CountriesList
+	}
+
     if (this.$element.is("select")) {
       this.addCountries()
     }
@@ -51,8 +63,8 @@
       
       this.$element.html('')
       this.$element.append('<option value=""></option>')
-      for (var country in CountriesList) {
-        this.$element.append('<option value="' + country + '">' + CountriesList[country] + '</option>')
+      for (var country in this.countryList) {
+        this.$element.append('<option value="' + country + '">' + this.countryList[country] + '</option>')
       }
       
       this.$element.val(value)
@@ -71,11 +83,11 @@
       
       $options.html('')
       $options.append('<li><a tabindex="-1" href="#" data-option=""></a></li>')
-      for (var country in CountriesList) {
+      for (var country in this.countryList) {
         if (this.options.flags == true) {
-          $options.append('<li><a tabindex="-1" href="#" data-option="' + country + '"><i class="icon-flag-' + country + '"></i>' + CountriesList[country] + '</a></li>')
+          $options.append('<li><a tabindex="-1" href="#" data-option="' + country + '"><i class="icon-flag-' + country + '"></i>' + this.countryList[country] + '</a></li>')
         } else {
-          $options.append('<li><a tabindex="-1" href="#" data-option="' + country + '">' + CountriesList[country] + '</a></li>')
+          $options.append('<li><a tabindex="-1" href="#" data-option="' + country + '">' + this.countryList[country] + '</a></li>')
         }
       }
       
@@ -83,9 +95,9 @@
       
       if (value) {
         if (this.options.flags == true) {
-          $toggle.html('<i class="icon-flag-' + value + '"></i> ' + CountriesList[value])
+          $toggle.html('<i class="icon-flag-' + value + '"></i> ' + this.countryList[value])
         } else {
-          $toggle.html(CountriesList[value])
+          $toggle.html(this.countryList[value])
         }
       }
       
@@ -96,9 +108,9 @@
       var value = this.options.country
       
       if (this.options.flags == true) {
-        this.$element.html('<i class="icon-flag-' + value + '"></i> ' + CountriesList[value])
+        this.$element.html('<i class="icon-flag-' + value + '"></i> ' + this.countryList[value])
       } else {
-        this.$element.html(CountriesList[value])
+        this.$element.html(this.countryList[value])
       }
     }
 
@@ -123,6 +135,7 @@
 
   $.fn.countries.defaults = {
     country: "",
+	countryList: "",
     flags: false
   }
   

--- a/docs/index.html
+++ b/docs/index.html
@@ -333,6 +333,12 @@
           </form>
           <pre class="prettyprint">&lt;select class="input-medium countries" data-country="US"&gt;&lt;/select&gt;</pre>
           
+          <p>Example for loading the list of countries, limited to a specific list of countries</p>
+          <form class="bs-docs-example form-inline">
+            <select class="input-medium countries" data-countryList="US,AG,AU"></select>
+          </form>
+          <pre class="prettyprint">&lt;select class="input-medium countries" data-countryList="US,AG,AU"&gt;&lt;/select&gt;</pre>
+          
           <p>Example for loading the list of countries in JavaScript and selecting a default country</p>
           <form class="bs-docs-example form-inline">
             <button onclick="$('#countries1').countries({country: 'US'});return false;" class="btn">Load Countries</button>

--- a/js/bootstrap-formhelpers-countries.js
+++ b/js/bootstrap-formhelpers-countries.js
@@ -29,6 +29,18 @@
     this.options = $.extend({}, $.fn.countries.defaults, options)
     this.$element = $(element)
     
+	if (this.options.countrylist) {
+		this.countryList = []
+		this.options.countrylist = this.options.countrylist.split(',')
+        for (var country in CountriesList) {
+			if ($.inArray(country, this.options.countrylist) >= 0) {
+				this.countryList[country] = CountriesList[country]
+			}
+		}
+	} else {
+		this.countryList = CountriesList
+	}
+
     if (this.$element.is("select")) {
       this.addCountries()
     }
@@ -51,8 +63,8 @@
       
       this.$element.html('')
       this.$element.append('<option value=""></option>')
-      for (var country in CountriesList) {
-        this.$element.append('<option value="' + country + '">' + CountriesList[country] + '</option>')
+      for (var country in this.countryList) {
+        this.$element.append('<option value="' + country + '">' + this.countryList[country] + '</option>')
       }
       
       this.$element.val(value)
@@ -71,11 +83,11 @@
       
       $options.html('')
       $options.append('<li><a tabindex="-1" href="#" data-option=""></a></li>')
-      for (var country in CountriesList) {
+      for (var country in this.countryList) {
         if (this.options.flags == true) {
-          $options.append('<li><a tabindex="-1" href="#" data-option="' + country + '"><i class="icon-flag-' + country + '"></i>' + CountriesList[country] + '</a></li>')
+          $options.append('<li><a tabindex="-1" href="#" data-option="' + country + '"><i class="icon-flag-' + country + '"></i>' + this.countryList[country] + '</a></li>')
         } else {
-          $options.append('<li><a tabindex="-1" href="#" data-option="' + country + '">' + CountriesList[country] + '</a></li>')
+          $options.append('<li><a tabindex="-1" href="#" data-option="' + country + '">' + this.countryList[country] + '</a></li>')
         }
       }
       
@@ -83,9 +95,9 @@
       
       if (value) {
         if (this.options.flags == true) {
-          $toggle.html('<i class="icon-flag-' + value + '"></i> ' + CountriesList[value])
+          $toggle.html('<i class="icon-flag-' + value + '"></i> ' + this.countryList[value])
         } else {
-          $toggle.html(CountriesList[value])
+          $toggle.html(this.countryList[value])
         }
       }
       
@@ -96,9 +108,9 @@
       var value = this.options.country
       
       if (this.options.flags == true) {
-        this.$element.html('<i class="icon-flag-' + value + '"></i> ' + CountriesList[value])
+        this.$element.html('<i class="icon-flag-' + value + '"></i> ' + this.countryList[value])
       } else {
-        this.$element.html(CountriesList[value])
+        this.$element.html(this.countryList[value])
       }
     }
 
@@ -123,6 +135,7 @@
 
   $.fn.countries.defaults = {
     country: "",
+	countryList: "",
     flags: false
   }
   


### PR DESCRIPTION
This changeset adds a data option of countryList so that instead of using the entire list of countries from bootstrap-formhelpers-countries.en_US.js a shorter list may be specified:

```
<select class="input-medium countries" data-countryList="US,AG,AU"></select>
```

I've added this to the index.html examples as well.
