### PR TITLE
Fix of misstyped CC for Mayotte (YT instead of MT)

### DIFF
--- a/js/bootstrap-formhelpers-countries.en_US.js
+++ b/js/bootstrap-formhelpers-countries.en_US.js
@@ -152,7 +152,7 @@
    'MQ': 'Martinique',
    'MR': 'Mauritania',
    'MU': 'Mauritius',
-   'MT': 'Mayotte',
+   'YT': 'Mayotte',
    'MX': 'Mexico',
    'FM': 'Micronesia',
    'MD': 'Moldova',

--- a/js/bootstrap-formhelpers-countries.es_ES.js
+++ b/js/bootstrap-formhelpers-countries.es_ES.js
@@ -163,7 +163,7 @@
    'MA': 'Marruecos',
    'MR': 'Mauritania',
    'MU': 'Mauricio',
-   'MT': 'Mayotte',
+   'YT': 'Mayotte',
    'MX': 'México',
    'FM': 'Micronesia',
    'MD': 'Moldavia',

--- a/js/bootstrap-formhelpers-countries.pt_BR.js
+++ b/js/bootstrap-formhelpers-countries.pt_BR.js
@@ -133,7 +133,7 @@ var BFHCountriesList = {
    'MQ': 'Martinica',
    'MR': 'Mauritânia',
    'MU': 'Maurício',
-   'MT': 'Mayotte',
+   'YT': 'Mayotte',
    'MX': 'México',
    'FM': 'Micronésia',
    'MD': 'Moldávia',


### PR DESCRIPTION
Three cases CC of Mayotte is wrong (MT) the correct is YT.
