### PR TITLE
Not honoring value="" is a big showstopper.  Easy to support it.

### DIFF
--- a/js/bootstrap-formhelpers-phone.js
+++ b/js/bootstrap-formhelpers-phone.js
@@ -47,6 +47,9 @@
         }
       }
       
+      if( !this.options.number && this.$element.val() )
+        this.options.number = this.$element.val().replace(/\D/g, '');
+      
       this.addFormatter();
     }
     


### PR DESCRIPTION
used in combination with any framework that has Form objects that repeat output into value="" as is customary, changing value="" to data-number="(number only value)" is pretty painful.  These two quick lines make this a happy citizen in ZF2 for example.  Hope it helps -- and nice work.
