### PR TITLE
keep .bfh-phone input from overwriting placeholder text when empty

### DIFF
--- a/js/bootstrap-formhelpers-phone.js
+++ b/js/bootstrap-formhelpers-phone.js
@@ -66,7 +66,7 @@
 
       formattedNumber = formatNumber(this.options.format, this.$element.val());
 
-      this.$element.val(formattedNumber);
+      if ('' !== formattedNumber.trim()) {this.$element.val(formattedNumber);}
     },
 
     displayFormatter: function () {
@@ -78,7 +78,7 @@
 
       formattedNumber = formatNumber(this.options.format, this.options.number);
 
-      this.$element.html(formattedNumber);
+      if ('' !== formattedNumber.trim()) {this.$element.val(formattedNumber);}
     },
 
     changeCountry: function (e) {


### PR DESCRIPTION
When a `.bfh-phone` element has no value, the `placeholder` attribute is overwritten with `" "` which is the value of `formattedNumber`.  The code below keeps that from happening.  Only tested in Chrome (31) for Mac (10.7.5).  Built it with `grunt` and it passed all tests.
