### PR TITLE
Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"issues": "https://github.com/vlamanna/BootstrapFormHelpers/issues"
 	},
 	"require": {
-		"jquery/jquery": "1.10.*",
+		"components/jquery": "1.10.*",
 		"twitter/bootstrap": "3.0.*"
 	}
 }


### PR DESCRIPTION
Currently the composer.json file does not work.  The repositories element is root level only.

It will need documenting that to control where jquery is accessable from, can be controlled with this in a projects composer.json file.

```
"config": {
    "component-dir": "web/assets",
    "component-baseurl": "/assets"
},
```

and that you can include it using:

```
"require": {
    "vlamanna/bootstrapformhelpers": "~2.3",
},
```

Also please register this package on packagist.org
