### PR TITLE
Phone - add support for placeholder attributes (with a test)

### DIFF
--- a/js/bootstrap-formhelpers-phone.js
+++ b/js/bootstrap-formhelpers-phone.js
@@ -62,11 +62,20 @@
     },
 
     loadFormatter: function () {
-      var formattedNumber;
+      var formattedNumber, value, placeholder;
 
-      formattedNumber = formatNumber(this.options.format, this.$element.val());
+      value = this.$element.val();
+      placeholder = this.$element.attr('placeholder');
 
-      this.$element.val(formattedNumber);
+      // If there is no value, but there is a placeholder, format that instead.
+      if (value == '' && placeholder !== undefined) {
+        formattedNumber = formatNumber(this.options.format, placeholder);
+        this.$element.attr('placeholder', formattedNumber);
+      } else {
+        formattedNumber = formatNumber(this.options.format, value);
+        this.$element.val(formattedNumber);
+      }
+
     },
 
     displayFormatter: function () {

--- a/js/tests/unit/bootstrap-formhelpers-phone.js
+++ b/js/tests/unit/bootstrap-formhelpers-phone.js
@@ -97,4 +97,12 @@ $(function () {
     phone.remove();
   });
   
+  test('should format the placeholder, if the value is blank (but not set the value)', function() {
+    var phoneHTML = '<input type="text" class="bfh-phone" placeholder="5555555555" data-format="+1 (ddd) ddd-dddd">',
+      phone = $(phoneHTML).bfhphone({format: '+1 (ddd) ddd-dddd'});
+
+    ok(phone.attr('placeholder') === '+1 (555) 555-5555', 'phone number (placeholder) is correctly formatted');
+
+    ok(phone.val()  === '', 'phone number (value) is correctly formatted');
+  });
 });


### PR DESCRIPTION
HTML5 added support for the "placeholder" attribute on inputs. It acts as a default value (greyed out by default) that is shown until the user adds their own input.

Previously, the phone input BFH would ignore the placeholder, and set the value (attribute of the input) to be the formattedNumber (typically nothing or "+1", if the format called for it). 

Now, if there is no value set, this looks to see if it can format the placeholder instead.

Let me know if more tests are needed!
