### PR TITLE
Fix accidental base-8 parseInt with leading zeroes (fixes #216)

### DIFF
--- a/js/bootstrap-formhelpers-number.js
+++ b/js/bootstrap-formhelpers-number.js
@@ -192,7 +192,7 @@
         value = this.options.min;
       }
       
-      return parseInt(value);
+      return parseInt(value, 10);
     },
     
     formatNumber: function() {


### PR DESCRIPTION
When a number field has leading zeroes and can be interpreted as an octal number, (e.g. 08), getValue interprets it as an octal number. In the android browser in particular, this parseInt("08"), even more oddly, returns zero! This causes odd "wrapping" behaviour.

Always specify a radix when using parseInt!

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt#Octal_interpretations_with_no_radix
