### PR TITLE
#223 Fix missing 'change' event on input element

### DIFF
--- a/dist/js/bootstrap-formhelpers.js
+++ b/dist/js/bootstrap-formhelpers.js
@@ -16814,7 +16814,7 @@ var BFHTimezonesList = {
           html = '';
         }
 
-        $el.find('input[type="hidden"]').val(val);
+        $el.find('input[type="hidden"]').val(val).change();
         $el.find('.bfh-selectbox-option').html(html);
       } else if (origHook) {
         return origHook.set(el,val);
@@ -16893,7 +16893,7 @@ var BFHTimezonesList = {
         '<div class="bfh-slider-handle"><div class="bfh-slider-value"></div></div>'
       );
       
-      this.$element.find('input[type="hidden"]').val(this.options.value);
+      this.$element.find('input[type="hidden"]').val(this.options.value).change();
       this.updateHandle(this.options.value);
       
       this.$element.on('mousedown.bfhslider.data-api', BFHSlider.prototype.mouseDown);
@@ -17042,7 +17042,7 @@ var BFHTimezonesList = {
     },
     set: function(el, val) {
       if ($(el).hasClass('bfh-slider')) {
-        $(el).find('input[type="hidden"]').val(val);
+        $(el).find('input[type="hidden"]').val(val).change();
         $(el).data('bfhslider').updateHandle(val);
       } else if (origHook) {
         return origHook.set(el,val);

--- a/js/bootstrap-formhelpers-selectbox.js
+++ b/js/bootstrap-formhelpers-selectbox.js
@@ -315,7 +315,7 @@
           html = '';
         }
 
-        $el.find('input[type="hidden"]').val(val);
+        $el.find('input[type="hidden"]').val(val).change();
         $el.find('.bfh-selectbox-option').html(html);
       } else if (origHook) {
         return origHook.set(el,val);

--- a/js/bootstrap-formhelpers-slider.js
+++ b/js/bootstrap-formhelpers-slider.js
@@ -46,7 +46,7 @@
         '<div class="bfh-slider-handle"><div class="bfh-slider-value"></div></div>'
       );
       
-      this.$element.find('input[type="hidden"]').val(this.options.value);
+      this.$element.find('input[type="hidden"]').val(this.options.value).change();
       this.updateHandle(this.options.value);
       
       this.$element.on('mousedown.bfhslider.data-api', BFHSlider.prototype.mouseDown);
@@ -195,7 +195,7 @@
     },
     set: function(el, val) {
       if ($(el).hasClass('bfh-slider')) {
-        $(el).find('input[type="hidden"]').val(val);
+        $(el).find('input[type="hidden"]').val(val).change();
         $(el).data('bfhslider').updateHandle(val);
       } else if (origHook) {
         return origHook.set(el,val);


### PR DESCRIPTION
#223

I decided to fire pure `change` change event, in case of plugins. Cause this event triggers to early, when `bfh-selectbox` not atomic changed.
