### PR TITLE
[Number picker] Allow specifying the amount the value should be increased/decreased by each time

### DIFF
--- a/js/bootstrap-formhelpers-number.js
+++ b/js/bootstrap-formhelpers-number.js
@@ -166,12 +166,12 @@
       
       value = this.getValue();
       
-        if(this.options.step === undefined){
-            value = value + 1;
-        }
-        else{ // if use has specified 'data-step' attribute in <input> tag
-            value = value + this.options.step;
-        }
+      if(this.options.step === undefined){
+        value = value + 1;
+      }
+      else{ // if use has specified 'data-step' attribute in <input> tag
+        value = value + this.options.step;
+      }
       
       this.$element.val(value).change();
     },
@@ -181,12 +181,12 @@
       
       value = this.getValue();
       
-        if(this.options.step === undefined){
-            value = value - 1;
-        }
-        else{ // if use has specified 'data-step' attribute in <input> tag
-            value = value - this.options.step;
-        }
+      if(this.options.step === undefined){
+        value = value - 1;
+      }
+      else{ // if use has specified 'data-step' attribute in <input> tag
+        value = value - this.options.step;
+      }
       
       this.$element.val(value).change();
     },


### PR DESCRIPTION
html example:
![for_github_comment](https://cloud.githubusercontent.com/assets/4966393/4146976/bb523a04-3412-11e4-9290-a91a00b0f336.png)
We set a value of 10 for 'data-step' attribute, so the value of this number picker will be increased/decreased by 10 every time. 
If user doesn't set this attribute, it will use 1 by default.
