### PR TITLE
Fix improper cursor on button hover (number formhelper only)

### DIFF
--- a/less/bootstrap-formhelpers-number.less
+++ b/less/bootstrap-formhelpers-number.less
@@ -7,5 +7,6 @@
 }
 
 .input-group > .bfh-number-btn:hover {
+  cursor: pointer;
   background-color: @number-button-hover-bg;
 }


### PR DESCRIPTION
This also needs to be done for a lot of the other buttons (particularly all the ones using `.input-group-addon`) but it isn't obvious in what way you'd want to do that. My recommendation would be a selector that grabbed the `.input-group-addon` children of any `.input-group` elements that have a class that start with `bfh` and giving them the `cursor: pointer` rule
