### PR TITLE
Correction to the Russian telephone number formatting.

### DIFF
--- a/dist/js/bootstrap-formhelpers.js
+++ b/dist/js/bootstrap-formhelpers.js
@@ -8058,7 +8058,7 @@ var BFHPhoneFormatList = {
   'QA': '+974 ddddddddd',
   'RE': '+262 ddddddddd',
   'RO': '+40 ddddddddd',
-  'RU': '+7 dddddddddd',
+  'RU': '+7 (ddd) ddd dd dd',
   'RW': '+250 ddddddddd',
   'ST': '+239 ddddddddd',
   'SH': '+290 ddddddddd',


### PR DESCRIPTION
Previously when entering a Russian telephone number there were not enough digits and the formatting was incorrect and missing the brackets for the area code.
Now when entering a Russian telephone number it is the correct format for 98% of commonly used numbers.

Further information can be found at, https://properrussian.com/2011/06/russian-phone-numbers.html